### PR TITLE
Run the pinned pnpm setup action on Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10.7.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -148,7 +148,7 @@ jobs:
           pip-audit -r apps/mcp-challenge/requirements.lock
           pip-audit -r apps/mcp-submit/requirements.lock
           pip-audit -r apps/validators/shared/requirements.lock
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10.7.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6


### PR DESCRIPTION
## Summary

Updates the pinned pnpm setup action from v4 to the current v6.0.10 release SHA.

The prior action targeted deprecated Node.js 20 and GitHub was forcing it onto Node.js 24. The new pinned release declares `using: node24` directly and keeps the existing `version` input contract.

## Verification

- source commit and `action.yml` verified from the official pnpm/action-setup repository
- action remains pinned to a full commit SHA
- no application, schema, dependency lock, or task-shell code changes
