### PR TITLE
Make the three-command local startup work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Local full-stack example. Replace every marked value before production use.
 POSTGRES_PASSWORD=replace-with-a-random-database-password
+POSTGRES_PORT=5433
 JWT_SECRET=replace-with-at-least-32-random-bytes
 
 # Browser-visible and backend URLs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,15 @@ jobs:
           POSTGRES_PASSWORD: ci-only-postgres-password
           JWT_SECRET: ci-only-jwt-secret-at-least-32-bytes
         run: docker compose config --quiet
+      - name: Verify repeatable database bootstrap
+        env:
+          POSTGRES_PASSWORD: ci-only-postgres-password
+          POSTGRES_PORT: "55432"
+        run: |
+          docker compose up -d postgres
+          docker compose run --rm migrate
+          docker compose run --rm migrate
+          docker compose down --volumes
       - name: Build application images
         run: |
           docker build -t championship-backend apps/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: ci-only-postgres-password
           POSTGRES_PORT: "55432"
+          JWT_SECRET: ci-only-jwt-secret-at-least-32-bytes
         run: |
           docker compose up -d postgres
           docker compose run --rm migrate

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ The frontend is served at `http://localhost:3003` and the backend at
 competition and its task metadata before participant testing; do not add real
 task data to this repository.
 
-For a non-container workflow:
+To run the application processes on the host while keeping PostgreSQL in
+Compose, these three commands are sufficient. `just install` creates `.env`
+from `.env.example` when it is missing, `just migrate` starts PostgreSQL and
+applies the schema, and `just dev` connects the backend to that database.
 
 ```bash
 just install

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    ports:
+      - "127.0.0.1:${POSTGRES_PORT:-5433}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
@@ -25,10 +27,14 @@ services:
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |
-        for migration in /migrations/*.sql; do
-          echo "Applying $${migration}"
-          psql -v ON_ERROR_STOP=1 -h postgres -U postgres -d championship -f "$${migration}"
-        done
+        if [ "$$(psql -h postgres -U postgres -d championship -Atqc "SELECT to_regclass('public.competitions') IS NOT NULL")" = "t" ]; then
+          echo "Database schema is already initialized."
+        else
+          for migration in /migrations/*.sql; do
+            echo "Applying $${migration}"
+            psql -v ON_ERROR_STOP=1 --single-transaction -h postgres -U postgres -d championship -f "$${migration}"
+          done
+        fi
 
   backend:
     build: ./apps/backend

--- a/justfile
+++ b/justfile
@@ -14,11 +14,13 @@ psql := "psql"
 #                                  CONSTANTS                                   #
 # ---------------------------------------------------------------------------- #
 
-db_host := env_var_or_default("DB_HOST", "postgres")
+db_host := env_var_or_default("DB_HOST", "localhost")
+db_port := env_var_or_default("DB_PORT", env_var_or_default("POSTGRES_PORT", "5433"))
 db_name := env_var_or_default("DB_NAME", "championship")
 db_user := env_var_or_default("DB_USER", "postgres")
-db_pass := env_var_or_default("DB_PASS", "postgres")
-db_url := "postgresql://" + db_user + ":" + db_pass + "@" + db_host + ":5432/" + db_name
+db_pass := env_var_or_default("DB_PASS", env_var_or_default("POSTGRES_PASSWORD", "postgres"))
+db_url := "postgresql://" + db_user + ":" + db_pass + "@" + db_host + ":" + db_port + "/" + db_name
+export DATABASE_URL := env_var_or_default("DATABASE_URL", db_url)
 
 # ---------------------------------------------------------------------------- #
 #                                   COMMANDS                                   #
@@ -31,12 +33,16 @@ default:
 #                                    META                                      #
 # ---------------------------------------------------------------------------- #
 
+[private]
+@ensure-env:
+    if [ ! -f .env ]; then cp .env.example .env; echo "Created .env from .env.example"; fi
+
 [group("meta")]
-install: backend-install frontend-install validators-install mcp-challenge-install mcp-submit-install
+install: ensure-env backend-install frontend-install validators-install mcp-challenge-install mcp-submit-install
 alias i := install
 
 [group("meta")]
-@dev:
+@dev: ensure-env
     (cd apps/backend && .venv/bin/uvicorn app.main:app --reload --host 0.0.0.0 --port 8003) & \
     cd apps/frontend && pnpm dev --port 3003
 
@@ -151,13 +157,10 @@ export PGOPTIONS := "--client-min-messages=warning"
 
 [group("database")]
 [script("bash")]
-migrate:
+migrate: ensure-env
     set -euo pipefail
-    for f in $(ls apps/backend/migrations/*.sql | sort); do
-        echo "Running $f..."
-        psql -q "{{db_url}}" -f "$f"
-    done
-    echo "Migrations complete."
+    docker compose up -d postgres
+    docker compose run --rm migrate
 alias m := migrate
 
 [group("database")]
@@ -165,12 +168,12 @@ alias m := migrate
 
 [group("database")]
 @db-reset:
-    psql -q "postgresql://{{db_user}}:{{db_pass}}@{{db_host}}:5432/postgres" -c "DROP DATABASE IF EXISTS {{db_name}}"
-    psql -q "postgresql://{{db_user}}:{{db_pass}}@{{db_host}}:5432/postgres" -c "CREATE DATABASE {{db_name}}"
+    docker compose down --volumes
 
 [group("database")]
-@db-shell:
-    psql "{{db_url}}"
+@db-shell: ensure-env
+    docker compose up -d postgres
+    docker compose exec postgres psql -U postgres -d championship
 
 # ---------------------------------------------------------------------------- #
 #                                    TESTS                                     #


### PR DESCRIPTION
## Summary

- make `just install` create the local `.env` when missing
- make `just migrate` start PostgreSQL in Compose and apply the single schema
- expose the Compose database on a conflict-resistant host port for `just dev`
- make repeated schema bootstrap safe and transactional
- route the host backend to the started database
- add CI coverage for first and repeated database bootstrap

## Root cause

The host-side recipe defaulted to the Docker-only `postgres` DNS name and ignored `POSTGRES_PASSWORD` from `.env.example`. The documented three-command workflow therefore could not work from a host shell.

## Verification

- Just variable and recipe expansion checks pass
- Compose configuration validates
- `git diff --check` passes
- CI boots PostgreSQL and runs the bootstrap twice