### PR TITLE
Avoid common local PostgreSQL port conflicts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Local full-stack example. Replace every marked value before production use.
 POSTGRES_PASSWORD=replace-with-a-random-database-password
-POSTGRES_PORT=5433
+POSTGRES_PORT=55432
 JWT_SECRET=replace-with-at-least-32-random-bytes
 
 # Browser-visible and backend URLs.

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
       timeout: 5s
       retries: 10
     ports:
-      - "127.0.0.1:${POSTGRES_PORT:-5433}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-55432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
 

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ psql := "psql"
 # ---------------------------------------------------------------------------- #
 
 db_host := env_var_or_default("DB_HOST", "localhost")
-db_port := env_var_or_default("DB_PORT", env_var_or_default("POSTGRES_PORT", "5433"))
+db_port := env_var_or_default("DB_PORT", env_var_or_default("POSTGRES_PORT", "55432"))
 db_name := env_var_or_default("DB_NAME", "championship")
 db_user := env_var_or_default("DB_USER", "postgres")
 db_pass := env_var_or_default("DB_PASS", env_var_or_default("POSTGRES_PASSWORD", "postgres"))


### PR DESCRIPTION
## Summary

- move the project-managed development PostgreSQL port from 5433 to 55432
- keep the Just backend URL and Compose port mapping aligned

## Root cause

A separate local PostgreSQL container commonly occupies 5433. The project database now uses a high dedicated port while remaining configurable through `POSTGRES_PORT`.

## Verification

- 55432 is free in the reproduced environment
- Just and Compose resolve the same port
- `git diff --check` passes